### PR TITLE
Fix infinite target generation on job change

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -708,4 +708,7 @@ end
 
 onResourceStop(Mining.Functions.removeJob, true)
 onPlayerLoaded(function() Wait(1000) Mining.Functions.checkForJob() end, true)
-RegisterNetEvent('QBCore:Client:OnJobUpdate', Mining.Functions.checkForJob)
+
+if Config.General.requiredJob then
+	RegisterNetEvent('QBCore:Client:OnJobUpdate', Mining.Functions.checkForJob)
+end


### PR DESCRIPTION
- This change will fix the issue where every time you change jobs, it generates all the mining stuff again, while keeping the old, causing duplicate or even multiplied target options